### PR TITLE
feat: Add another view, with topological order

### DIFF
--- a/ItemInfo.tsx
+++ b/ItemInfo.tsx
@@ -100,7 +100,7 @@ export const allItems = [
     ingredientList: [{ name: "Copper Ore", amount: 1 }],
   },
   {
-    name: "Silicone",
+    name: "Silicon",
     itemsPerMin: 20,
     building: "Furnace",
     value: 2,
@@ -137,7 +137,7 @@ export const allItems = [
     value: 10,
     ingredientList: [
       { name: "Copper Wire", amount: 3 },
-      { name: "Silicone", amount: 2 },
+      { name: "Silicon", amount: 2 },
     ],
   },
   {


### PR DESCRIPTION
Add a separate view (topological view) with a middle ground between summary and tree view.


## What does it have

- It shows each item in topological order (each item only depends on items after it)
- Shows direct dependencies per item only and percent from each dependency

<img width="952" alt="Screenshot 2023-06-30 at 17 39 17" src="https://github.com/frosty656/frosty656.github.io/assets/28708963/dc01c956-76f1-452f-abe3-c0c1271a9578">
